### PR TITLE
Update Offline Solution Setup in README and update to @apollo/client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const client = new ApolloClient({
 ```javascript
 import { ApolloClient } from 'apollo-client'
 import { cacheFirstNetworkErrorLink } from 'apollo-link-network-error'
-import {ApolloLink} from '@apollo/client';
+import { ApolloLink } from '@apollo/client';
 
 const cache = new InMemoryCache()
 // Create the cache first network error link

--- a/README.md
+++ b/README.md
@@ -48,14 +48,13 @@ const client = new ApolloClient({
 ### Setup
 
 ```javascript
-import { ApolloClient } from 'apollo-client'
+import { ApolloClient, ApolloLink } from '@apollo/client'
 import { cacheFirstNetworkErrorLink } from 'apollo-link-network-error'
-import { ApolloLink } from '@apollo/client';
 
 const cache = new InMemoryCache()
 // Create the cache first network error link
 const errorIgnoreLink = cacheFirstNetworkErrorLink(cache)
-const link = ApolloLink.from([errorLink, errorIgnoreLink, httpLink]);
+const link = ApolloLink.from([errorLink, errorIgnoreLink, httpLink])
 const client = new ApolloClient({
   cache,
   link,

--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ const client = new ApolloClient({
 ```javascript
 import { ApolloClient } from 'apollo-client'
 import { cacheFirstNetworkErrorLink } from 'apollo-link-network-error'
+import {ApolloLink} from '@apollo/client';
 
 const cache = new InMemoryCache()
 // Create the cache first network error link
 const errorIgnoreLink = cacheFirstNetworkErrorLink(cache)
+const link = ApolloLink.from([errorLink, errorIgnoreLink, httpLink]);
 const client = new ApolloClient({
   cache,
-  from([errorLink, errorIgnoreLink, httpLink]),
+  link,
 })
 
 persistCache({ cache, storage: AsyncStorage })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,76 @@
 {
   "name": "apollo-link-network-error",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.3.21",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.21.tgz",
+      "integrity": "sha512-RAmZReFuKCKx0Rs5C0nVJwKomAHUHn+gGP/YvbEsXQWu0sXoncEUZa71UqlfCPVXa/0MkYOIbCXSQdOcuRrHgw==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.8.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "@wry/equality": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+          "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+              "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+            }
+          }
+        },
+        "graphql-tag": {
+          "version": "2.12.5",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+          "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+              "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+            }
+          }
+        },
+        "ts-invariant": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.8.2.tgz",
+          "integrity": "sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+              "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+            }
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -213,6 +280,11 @@
           "dev": true
         }
       }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
@@ -804,12 +876,39 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
-    "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+    "@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
+    },
+    "@wry/context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "abab": {
@@ -892,28 +991,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.20"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
-      "integrity": "sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==",
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
       }
     },
     "argparse": {
@@ -2224,6 +2301,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "html-encoding-sniffer": {
@@ -3842,8 +3927,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -4019,6 +4103,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "make-dir": {
@@ -4241,6 +4333,11 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4340,6 +4437,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optionator": {
@@ -4537,6 +4643,16 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "psl": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
@@ -4568,8 +4684,7 @@
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-      "dev": true
+      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
     "realpath-native": {
       "version": "1.1.0",
@@ -5413,6 +5528,11 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -5528,14 +5648,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "requires": {
-        "tslib": "^1.9.3"
       }
     },
     "ts-jest": {
@@ -5957,15 +6069,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "apollo-link": "^1.2.13"
+    "@apollo/client": "^3.3.21"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",

--- a/src/NetworkErrorLink.ts
+++ b/src/NetworkErrorLink.ts
@@ -4,7 +4,7 @@ import {
   NextLink,
   Observable,
   Operation,
-} from 'apollo-link'
+} from '@apollo/client'
 
 export interface INetworkResponse {
   networkError: any

--- a/src/handler/cacheFirstHandler.ts
+++ b/src/handler/cacheFirstHandler.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'apollo-link'
+import { DocumentNode } from '@apollo/client';
 import { INetworkResponse } from '../NetworkErrorLink'
 
 interface Query<TVariables> {

--- a/src/testUtils/utils.ts
+++ b/src/testUtils/utils.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable, execute } from 'apollo-link'
+import { ApolloLink, Observable, execute } from '@apollo/client';
 import { NetworkErrorLink, NetworkErrorHandler } from '../NetworkErrorLink'
 import gql from 'graphql-tag'
 


### PR DESCRIPTION
The readme code example for the offline solution setup didn't work, so I updated it to the code that worked for me. 

Secondly, Apollo now suggests migrating to `@apollo/client` and removing `apollo-link`. Since I've migrated to `@apollo/client` in my codebase, using `apollo-link` was giving a Typescript error so I switched your code to `@apollo/client` to keep it up to date and compatible with people using `@apollo/client`.

This package is really great—such a good fix for the frustrating issue of the 'cache-and-network' causing an error when offline. Thank you!